### PR TITLE
Fatten mode vore. Voracious Trait fullness & Stuckage Preference

### DIFF
--- a/GainStation13/code/mobs/chocoslime.dm
+++ b/GainStation13/code/mobs/chocoslime.dm
@@ -103,4 +103,6 @@
 		if(L.reagents)
 			if(!L.is_mouth_covered(head_only = 1))
 				L.reagents.add_reagent(food_fed, food_per_feeding)
+				if(HAS_TRAIT(L, TRAIT_VORACIOUS))
+					fullness_add = fullness_add * 0.67
 				L.fullness += (fullness_add)

--- a/GainStation13/code/modules/client/preferences/preferences.dm
+++ b/GainStation13/code/modules/client/preferences/preferences.dm
@@ -15,6 +15,8 @@
 	var/weight_gain_viruses = FALSE
 	///Extreme weight gain
 	var/weight_gain_extreme = FALSE
+	///stuckage
+	var/stuckage = FALSE
 
 	///Does the person wish to be involved with non-con weight gain events?
 	var/noncon_weight_gain = FALSE

--- a/code/__DEFINES/voreconstants.dm
+++ b/code/__DEFINES/voreconstants.dm
@@ -6,6 +6,7 @@
 #define DM_DRAGON "Dragon"
 #define DM_ABSORB "Absorb"
 #define DM_UNABSORB "Un-absorb"
+#define DM_FATTEN "Fatten"
 
 #define isbelly(A) istype(A, /obj/belly)
 

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -231,7 +231,7 @@
 
 /datum/quirk/voracious
 	name = "Voracious"
-	desc = "Nothing gets between you and your food. You eat twice as fast as everyone else!"
+	desc = "Nothing gets between you and your food. You eat twice as fast, get half as full and recover from stuffing twice as fast!"
 	value = 1
 	category = CATEGORY_FOOD
 	mob_trait = TRAIT_VORACIOUS

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -231,7 +231,7 @@
 
 /datum/quirk/voracious
 	name = "Voracious"
-	desc = "Nothing gets between you and your food. You eat twice as fast, get half as full and recover from stuffing twice as fast!"
+	desc = "Nothing gets between you and your food. You eat and recover from stuffing twice as fast, while getting less full!"
 	value = 1
 	category = CATEGORY_FOOD
 	mob_trait = TRAIT_VORACIOUS

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -12,7 +12,7 @@
 	if(!istype(L))
 		return ..()
 
-	if(L.fatness > 5000)
+	if(L.fatness > 5000 && L.client?.prefs?.stuckage)
 		if(rand(1, 3) == 1)
 			L.doorstuck = 1
 			L.visible_message("<span class'danger'>[L] gets stuck in the doorway!</span>")
@@ -22,7 +22,7 @@
 			L.Knockdown(1)
 		return ..()
 
-	else if(L.fatness > 3000)
+	else if(L.fatness > 3000 && L.client?.prefs?.stuckage)
 		if(rand(1, 5) == 1)
 			L.doorstuck = 1
 			L.visible_message("<span class'danger'>[L] gets stuck in the doorway!</span>")
@@ -35,7 +35,7 @@
 			to_chat(L, "<span class='danger'>With great effort, you manage to squeeze your massive form through  \the [src]. It's a tight fit, but you successfully navigate the narrow opening, barely avoiding getting stuck.</span>")
 			return ..()
 
-	else if(L.fatness > 1890)
+	else if(L.fatness > 1890  && L.client?.prefs?.stuckage)
 		if(rand(1, 5) == 1)
 			L.visible_message("<span class'danger'>[L]'s hips brush against the doorway...</span>")
 			to_chat(L, "<span class='danger'>As you pass through  \the [src], you feel a slight brushing against your hips. The [src] frame accommodates your form, but it's a close fit..</span>")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1059,6 +1059,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Weight Gain - Weapons:</b><a href='?_src_=prefs;preference=weight_gain_weapons'>[weight_gain_weapons == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 			dat += "<b>Weight Gain - Magic:</b><a href='?_src_=prefs;preference=weight_gain_magic'>[weight_gain_magic == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 			dat += "<b>Weight Gain - Viruses:</b><a href='?_src_=prefs;preference=weight_gain_viruses'>[weight_gain_viruses == TRUE ? "Enabled" : "Disabled"]</a><BR>"
+
+			dat += "<h2>GS13 Gameplay Preferences</h2>"
+			dat += "<b>Stuckage (weight results in getting stuck in doors):</b><a href='?_src_=prefs;preference=stuckage'>[stuckage == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 			dat += "<b>Extreme Weight Gain (Sprite Size scales with weight):</b><a href='?_src_=prefs;preference=weight_gain_extreme'>[weight_gain_extreme == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 
 			//Add the Hyper stuff below here
@@ -2628,6 +2631,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					weight_gain_extreme = !weight_gain_extreme
 				if("noncon_weight_gain")
 					noncon_weight_gain = !noncon_weight_gain
+				if("stuckage")
+					stuckage = !stuckage
 				if("max_fatness")
 					var/pickedweight = input(user,
 						"Choose your max fatness level, your weight will not go beyond this. None will let you gain without a limit",

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -158,6 +158,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["wl_rate"] >> wl_rate
 	S["noncon_weight_gain"] >> noncon_weight_gain
 	S["max_weight"] >> max_weight 
+	S["stuckage"] >> stuckage
 
 
 	//try to fix any outdated data if necessfary
@@ -298,6 +299,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["wl_rate"], wl_rate)
 	WRITE_FILE(S["noncon_weight_gain"], noncon_weight_gain)
 	WRITE_FILE(S["max_weight"], max_weight)
+	WRITE_FILE(S["stuckage"], stuckage)
 
 	return 1
 

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -53,7 +53,10 @@
 	checkLiked(fraction, M)
 	reagents.reaction(M, INGEST, fraction)
 	reagents.trans_to(M, gulp_size)
-	M.fullness += min(gulp_size, reagents.total_volume) // GS13 drinks will fill your stomach
+	if(HAS_TRAIT(M, TRAIT_VORACIOUS))
+		M.fullness += min(gulp_size * 0.67, reagents.total_volume * 0.67)
+	else
+		M.fullness += min(gulp_size, reagents.total_volume) // GS13 drinks will fill your stomach
 	playsound(M.loc,'sound/items/drink.ogg', rand(10,50), 1)
 	return 1
 

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -140,6 +140,8 @@ All foods are distributed among various categories. Use common sense.
 			if(M.satiety > -200)
 				M.satiety -= junkiness
 			playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+			if(HAS_TRAIT(M, TRAIT_VORACIOUS))
+				bitevolume = bitevolume * 0.67
 			M.fullness += bitevolume;
 			if(reagents.total_volume)
 				SEND_SIGNAL(src, COMSIG_FOOD_EATEN, M, user)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1502,6 +1502,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		H.adjust_fatness(nutritionThatBecomesFat, FATTENING_TYPE_FOOD)
 	if(H.fullness > FULLNESS_LEVEL_EMPTY)//GS13 stomach-emptying routine
 		var/ticksToEmptyStomach = 20 // GS13 how many ticks it takes to decrease the fullness by 1
+		if(HAS_TRAIT(H, TRAIT_VORACIOUS))
+			ticksToEmptyStomach = ticksToEmptyStomach * 0.5
 		H.fullness -= 1/ticksToEmptyStomach
 	if (H.fullness > FULLNESS_LEVEL_BLOATED) //GS13 overeating depends on fullness now
 		if(H.overeatduration < 5000) //capped so people don't take forever to unfat

--- a/modular_citadel/code/modules/vore/eating/belly_dat_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/belly_dat_vr.dm
@@ -35,7 +35,7 @@
 	var/can_taste = FALSE					// If this belly prints the flavor of prey when it eats someone.
 
 	var/tmp/digest_mode = DM_HOLD			// Whether or not to digest. Default to not digest.
-	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_NOISY)	// Possible digest modes
+	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_NOISY, DM_FATTEN)	// Possible digest modes
 	var/tmp/mob/living/owner				// The mob whose belly this is.
 	var/tmp/list/internal_contents = list()	// People/Things you've eaten into this belly!
 	var/tmp/is_full							// Flag for if digested remeans are present. (for disposal messages)

--- a/modular_citadel/code/modules/vore/eating/belly_obj_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/belly_obj_vr.dm
@@ -40,7 +40,7 @@
 	var/is_wet = TRUE						// Is this belly inside slimy parts?
 
 	//I don't think we've ever altered these lists. making them static until someone actually overrides them somewhere.
-	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_NOISY,DM_ABSORB,DM_UNABSORB)	// Possible digest modes
+	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_NOISY,DM_ABSORB,DM_UNABSORB, DM_FATTEN)	// Possible digest modes
 
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/digest_mode = DM_HOLD				// Current mode the belly is set to from digest_modes (+transform_modes if human)
@@ -227,6 +227,11 @@
 	items_preserved.Cut()
 	owner.update_icons()
 
+	var/mob/living/carbon/predator = owner
+	if(iscarbon(predator))
+		if(digest_mode == DM_FATTEN && predator.fat_hider == src)
+			predator.fat_show()
+	
 	return count
 
 // Release a specific atom from the contents of this belly into the owning mob's location.
@@ -273,6 +278,17 @@
 	if(!silent)
 		owner.visible_message("<font color='green'><b>[owner] expels [M] from their [lowertext(name)]!</b></font>")
 	owner.update_icons()
+
+	var/mob/living/carbon/predator = owner
+	if(iscarbon(predator))
+		if(digest_mode == DM_FATTEN && predator.fat_hider == src)
+			var/preys_fatness = 0
+			for(var/mob/living/carbon/prey in contents)
+				preys_fatness += prey.fatness
+			if(preys_fatness > predator.fatness)
+				predator.fat_hide(preys_fatness, src)
+			else
+				predator.fat_show()
 	return TRUE
 
 // Actually perform the mechanics of devouring the tasty prey.

--- a/modular_citadel/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/bellymodes_vr.dm
@@ -62,6 +62,25 @@
 	if(digest_mode == DM_HOLD)
 		return SSBELLIES_PROCESSED
 
+///////////////////////////// DM_FATTEN /////////////////////////////
+	if(digest_mode == DM_FATTEN)
+		var/preys_fatness = 0
+		var/mob/living/carbon/predator = owner
+		if(iscarbon(predator))
+			for(var/mob/living/M in contents)
+				var/mob/living/carbon/prey = M
+				if(iscarbon(prey) && predator.fatness_real)
+					prey.adjust_fatness(predator.fatness_real * 0.01, FATTENING_TYPE_FOOD)
+					predator.adjust_fatness(-predator.fatness_real * 0.01, FATTENING_TYPE_FOOD)
+					predator.nutrition -= 5
+				preys_fatness += prey.fatness
+
+		if(!predator.fat_hider || predator.fat_hider == src)
+			if(preys_fatness > predator.fatness)
+				predator.fat_hide(preys_fatness, src)
+		if(predator.fat_hider != src)
+			predator.fat_show()		
+
 //////////////////////////// DM_DIGEST ////////////////////////////
 	else if(digest_mode == DM_DIGEST)
 		if(HAS_TRAIT(owner, TRAIT_PACIFISM)) //obvious.

--- a/modular_citadel/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/bellymodes_vr.dm
@@ -70,9 +70,11 @@
 			for(var/mob/living/M in contents)
 				var/mob/living/carbon/prey = M
 				if(iscarbon(prey) && predator.fatness_real)
-					prey.adjust_fatness(predator.fatness_real * 0.01, FATTENING_TYPE_FOOD)
-					predator.adjust_fatness(-predator.fatness_real * 0.01, FATTENING_TYPE_FOOD)
-					predator.nutrition -= 5
+					if(predator.fatness_real > 50)
+						prey.adjust_fatness(predator.fatness_real * 0.02, FATTENING_TYPE_FOOD)
+						predator.adjust_fatness(-predator.fatness_real * 0.02, FATTENING_TYPE_FOOD)
+						if(predator.nutrition > NUTRITION_LEVEL_HUNGRY)
+							predator.nutrition -= 3
 				preys_fatness += prey.fatness
 
 		if(!predator.fat_hider || predator.fat_hider == src)

--- a/modular_citadel/code/modules/vore/eating/vorepanel_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/vorepanel_vr.dm
@@ -119,6 +119,8 @@
 				spanstyle = "color:purple;"
 			if(DM_DRAGON)
 				spanstyle = "color:blue;"
+			if(DM_FATTEN)
+				spanstyle = "color:orange;"
 
 		dat += "<span style='[spanstyle]'> ([B.contents.len])</span></a></li>"
 


### PR DESCRIPTION
Added fatten vore belly mode. Adds 2% of predator's fatness to the preys, making them hungrier.
Fatten mode also uses fatness hiding to display the combined fatness of preys as the fatness of the predator while holding them in a fatten mode belly
Voracious trait now also modifies fullness added values to make the eater able to eat/drink twice as much. Also makes fullness decay twice as fast
Added stuckage pref, it and XWG are now under "GS13 Gameplay Preferences"