### PR TITLE
Nanites Fixes & BFI Nanites

### DIFF
--- a/GainStation13/code/modules/research/nanites/nanite_programs/fattening.dm
+++ b/GainStation13/code/modules/research/nanites/nanite_programs/fattening.dm
@@ -1,0 +1,111 @@
+/datum/nanite_rule/fatness
+	name = "BFI"
+	desc = "Checks the host's BFI."
+
+	var/threshold = 50
+	var/above = TRUE
+
+/datum/nanite_rule/fatness/check_rule()
+	if(iscarbon(program.host_mob))
+		var/mob/living/carbon/C = program.host_mob
+		var/BFI = C.fatness_real
+		if(above)
+			if(BFI >= threshold)
+				return TRUE
+		else
+			if(BFI < threshold)
+				return TRUE
+		return FALSE
+	else
+		return FALSE
+
+/datum/nanite_rule/fatness/display()
+	return "[name] [above ? ">" : "<"] [threshold]"
+
+/datum/nanite_program/sensor/fat_sensor
+	name = "BFI Sensor"
+	desc = "The nanites receive a signal when the host's BFI is below or exceeds a certain amount."
+	can_rule = TRUE
+	var/spent = FALSE
+
+/datum/nanite_program/sensor/fat_sensor/register_extra_settings()
+	. = ..()
+	extra_settings[NES_FATNESS] = new /datum/nanite_extra_setting/number(0, 0, 3440, "BFI")
+	extra_settings[NES_DIRECTION] = new /datum/nanite_extra_setting/boolean(TRUE, "Above", "Below")
+
+/datum/nanite_program/sensor/fat_sensor/check_event()
+	if(iscarbon(host_mob))
+		var/mob/living/carbon/C = host_mob
+		var/datum/nanite_extra_setting/level = extra_settings[NES_FATNESS]
+		var/datum/nanite_extra_setting/direction = extra_settings[NES_DIRECTION]
+		var/detected = FALSE
+		if(direction.get_value())
+			if(C.fatness >= level.get_value())
+				detected = TRUE
+		else
+			if(C.fatness < level.get_value())
+				detected = TRUE
+
+		if(detected)
+			if(!spent)
+				spent = TRUE
+				return TRUE
+			return FALSE
+		else
+			spent = FALSE
+			return FALSE
+	return FALSE
+
+/datum/nanite_program/sensor/fat_sensor/make_rule(datum/nanite_program/target)
+	var/datum/nanite_rule/fatness/rule = new(target)
+	var/datum/nanite_extra_setting/direction = extra_settings[NES_DIRECTION]
+	var/datum/nanite_extra_setting/level = extra_settings[NES_FATNESS]
+	rule.above = direction.get_value()
+	rule.threshold = level.get_value()
+	return rule
+
+/datum/design/nanites/fat_sensor
+	name = "BFI Sensor"
+	desc = "The nanites boost can detect the host's BFI."
+	id = "fat_sensor_nanites"
+	program_type = /datum/nanite_program/sensor/fat_sensor
+	category = list("Sensor Nanites")
+
+/datum/nanite_program/fat_adjuster
+	name = "BFI Regulator"
+	desc = "The nanites act on the host's adipose tissues, removing or adding based on the specified preference. Nanites consumed are equal to value added/lost"
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+
+/datum/nanite_program/fat_adjuster/register_extra_settings()
+	. = ..()
+	extra_settings[NES_FATNESS] = new /datum/nanite_extra_setting/number(0, -10, 10, "BFI")
+
+/datum/nanite_program/fat_adjuster/check_conditions()
+	var/datum/nanite_extra_setting/BFI = extra_settings[NES_FATNESS]
+	if(iscarbon(host_mob))
+		var/mob/living/carbon/C = host_mob
+		if(BFI.get_value() < 0)
+			if(C.fatness_real <= 0)
+				return FALSE
+	else
+		return FALSE
+	return ..()
+
+/datum/nanite_program/fat_adjuster/active_effect()
+	var/datum/nanite_extra_setting/BFI = extra_settings[NES_FATNESS]
+	if(iscarbon(host_mob))
+		var/mob/living/carbon/C = host_mob
+		if(BFI.get_value() > 0)
+			if(consume_nanites(BFI.get_value()))
+				C.adjust_fatness(BFI.get_value(), FATTENING_TYPE_ITEM)
+		else
+			if(consume_nanites(-(BFI.get_value())))
+				C.adjust_fatness(BFI.get_value(), FATTENING_TYPE_WEIGHT_LOSS)
+
+/datum/design/nanites/fat_adjuster
+	name = "BFI Regulator"
+	desc = "The nanites adjust the host's BFI."
+	id = "fat_adjuster_nanites"
+	program_type = /datum/nanite_program/fat_adjuster
+	category = list("Medical Nanites")

--- a/code/__DEFINES/nanites.dm
+++ b/code/__DEFINES/nanites.dm
@@ -42,3 +42,7 @@
 #define NES_BUTTON_NAME "Button Name"
 #define NES_ICON "Icon"
 #define NES_COLOR "Color"
+
+//GS13 DEFINES
+#define NES_FATNESS "BFI"
+#define NES_FAT_GAIN_LOSS "Loss/Gain"

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -9,25 +9,11 @@
 /datum/nanite_program/regenerative/check_conditions()
 	if(!host_mob.getBruteLoss() && !host_mob.getFireLoss())
 		return FALSE
-	if(iscarbon(host_mob))
-		var/mob/living/carbon/C = host_mob
-		var/list/parts = C.get_damaged_bodyparts(TRUE,TRUE, status = BODYPART_ORGANIC)
-		if(!parts.len)
-			return FALSE
 	return ..()
 
 /datum/nanite_program/regenerative/active_effect()
-	if(iscarbon(host_mob))
-		var/mob/living/carbon/C = host_mob
-		var/list/parts = C.get_damaged_bodyparts(TRUE,TRUE, status = BODYPART_ORGANIC)
-		if(!parts.len)
-			return
-		for(var/obj/item/bodypart/L in parts)
-			if(L.heal_damage(0.5/parts.len, 0.5/parts.len, null, BODYPART_ORGANIC))
-				host_mob.update_damage_overlays()
-	else
-		host_mob.adjustBruteLoss(-0.5, TRUE)
-		host_mob.adjustFireLoss(-0.5, TRUE)
+	host_mob.adjustBruteLoss(-0.5, TRUE)
+	host_mob.adjustFireLoss(-0.5, TRUE)
 
 /datum/nanite_program/temperature
 	name = "Temperature Adjustment"
@@ -173,20 +159,8 @@
 	rogue_types = list(/datum/nanite_program/suffocating, /datum/nanite_program/necrotic)
 
 /datum/nanite_program/regenerative_advanced/active_effect()
-	if(iscarbon(host_mob))
-		var/mob/living/carbon/C = host_mob
-		var/list/parts = C.get_damaged_bodyparts(TRUE,TRUE, status = BODYPART_ORGANIC)
-		if(!parts.len)
-			return
-		var/update = FALSE
-		for(var/obj/item/bodypart/L in parts)
-			if(L.heal_damage(3/parts.len, 3/parts.len, null, BODYPART_ORGANIC))
-				update = TRUE
-		if(update)
-			host_mob.update_damage_overlays()
-	else
-		host_mob.adjustBruteLoss(-3, TRUE)
-		host_mob.adjustFireLoss(-3, TRUE)
+	host_mob.adjustBruteLoss(-3, TRUE)
+	host_mob.adjustFireLoss(-3, TRUE)
 
 /datum/nanite_program/brain_heal_advanced
 	name = "Neural Reimaging"

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -256,8 +256,8 @@
 	if(!sentence.get_value())
 		return
 	if(inclusive.get_value())
-		if(findtextEx(hearing_args[HEARING_RAW_MESSAGE], sentence))
+		if(findtext(hearing_args[HEARING_RAW_MESSAGE], sentence.get_value()))
 			send_code()
 	else
-		if(hearing_args[HEARING_RAW_MESSAGE] == sentence)
+		if(hearing_args[HEARING_RAW_MESSAGE] == sentence.get_value())
 			send_code()

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -999,7 +999,7 @@
 	description = "Nanite programs that require complex biological interaction."
 	prereq_ids = list("nanite_base","biotech")
 	design_ids = list("regenerative_nanites", "bloodheal_nanites", "coagulating_nanites","poison_nanites","flesheating_nanites",\
-					"sensor_crit_nanites","sensor_death_nanites", "sensor_health_nanites", "sensor_damage_nanites")
+					"sensor_crit_nanites","sensor_death_nanites", "sensor_health_nanites", "sensor_damage_nanites", "fat_sensor_nanites", "fat_adjuster_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3121,6 +3121,7 @@
 #include "GainStation13\code\modules\reagents\reagent_containers\barrel_tank.dm"
 #include "GainStation13\code\modules\research\designs\autolathe.dm"
 #include "GainStation13\code\modules\research\designs\nutri_designs.dm"
+#include "GainStation13\code\modules\research\nanites\nanite_programs\fattening.dm"
 #include "GainStation13\code\modules\research\techweb\nutritech_nodes.dm"
 #include "GainStation13\code\modules\surgery\organs\augments.dm"
 #include "GainStation13\code\modules\vending\gatocola.dm"


### PR DESCRIPTION
Fixed health-restoring nanite programs
Fixed Voice Sensor nanite programs
Added BFI Sensor and BFI Regulator nanite programs, found in the Biological Nanite Programming tech node. Sensor sends code if the host is above/under the specified amount of fatness, Regulator adds/removes the specified amount of fatness every activations, using up nanites.