### PR TITLE
adds prefs for nanite fattening

### DIFF
--- a/GainStation13/code/mechanics/fatness.dm
+++ b/GainStation13/code/mechanics/fatness.dm
@@ -96,6 +96,10 @@
 			if(!client?.prefs?.weight_gain_viruses)
 				return FALSE
 
+		if(FATTENING_TYPE_NANITES)
+			if(!client?.prefs?.weight_gain_nanites)
+				return FALSE
+
 		if(FATTENING_TYPE_WEIGHT_LOSS)
 			if(HAS_TRAIT(src, TRAIT_WEIGHT_LOSS_IMMUNE))
 				return FALSE

--- a/GainStation13/code/modules/client/preferences/preferences.dm
+++ b/GainStation13/code/modules/client/preferences/preferences.dm
@@ -13,6 +13,8 @@
 	var/weight_gain_magic = FALSE
 	///Weight gain from viruses
 	var/weight_gain_viruses = FALSE
+	///Weight gain from nanites
+	var/weight_gain_nanites = FALSE
 	///Blueberry Inflation
 	var/blueberry_inflation = FALSE
 	///Extreme weight gain

--- a/GainStation13/code/modules/research/nanites/nanite_programs/fattening.dm
+++ b/GainStation13/code/modules/research/nanites/nanite_programs/fattening.dm
@@ -98,7 +98,7 @@
 		var/mob/living/carbon/C = host_mob
 		if(BFI.get_value() > 0)
 			if(consume_nanites(BFI.get_value()))
-				C.adjust_fatness(BFI.get_value(), FATTENING_TYPE_ITEM)
+				C.adjust_fatness(BFI.get_value(), FATTENING_TYPE_NANITES)
 		else
 			if(consume_nanites(-(BFI.get_value())))
 				C.adjust_fatness(BFI.get_value(), FATTENING_TYPE_WEIGHT_LOSS)
@@ -150,7 +150,7 @@
 /datum/nanite_program/bwomf/on_trigger(comm_message)
 	if(iscarbon(host_mob))
 		var/mob/living/carbon/C = host_mob
-		C.adjust_fatness(100, FATTENING_TYPE_ITEM)
+		C.adjust_fatness(100, FATTENING_TYPE_NANITES)
 		to_chat(C, "<span class='warning'>[pick("Your belly expands quickly!", "Fat envelops you further!", "Lard grows all over you!")]</span>")
 
 /datum/design/nanites/bwomf

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -527,6 +527,7 @@ GLOBAL_LIST_INIT(lighter_reskins, list(ZIPPO_SKIN_PLAIN = "plain", ZIPPO_SKIN_DA
 #define FATTENING_TYPE_WEAPON "weapon"
 #define FATTENING_TYPE_MAGIC "magic"
 #define FATTENING_TYPE_VIRUS "virus"
-#define FATTENING_TYPE_WEIGHT_LOSS "weight_loss" 
+#define FATTENING_TYPE_NANITES "nanites"
+#define FATTENING_TYPE_WEIGHT_LOSS "weight_loss"
 
 #define FATNESS_TO_WEIGHT_RATIO 0.25

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1063,6 +1063,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Weight Gain - Weapons:</b><a href='?_src_=prefs;preference=weight_gain_weapons'>[weight_gain_weapons == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 			dat += "<b>Weight Gain - Magic:</b><a href='?_src_=prefs;preference=weight_gain_magic'>[weight_gain_magic == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 			dat += "<b>Weight Gain - Viruses:</b><a href='?_src_=prefs;preference=weight_gain_viruses'>[weight_gain_viruses == TRUE ? "Enabled" : "Disabled"]</a><BR>"
+			dat += "<b>Weight Gain - Nanites:</b><a href='?_src_=prefs;preference=weight_gain_nanites'>[weight_gain_nanites == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 			dat += "<b>Blueberry Inflation:</b><a href='?_src_=prefs;preference=blueberry_inflation'>[blueberry_inflation == TRUE ? "Enabled" : "Disabled"]</a><BR>"
 
 			dat += "<h2>GS13 Gameplay Preferences</h2>"
@@ -2636,6 +2637,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					weight_gain_magic = !weight_gain_magic
 				if("weight_gain_viruses")
 					weight_gain_viruses = !weight_gain_viruses
+				if("weight_gain_nanites")
+					weight_gain_nanites = !weight_gain_nanites
 				if("weight_gain_extreme")
 					weight_gain_extreme = !weight_gain_extreme
 				if("noncon_weight_gain")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -152,6 +152,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["weight_gain_items"] >> weight_gain_items
 	S["weight_gain_magic"] >> weight_gain_magic
 	S["weight_gain_viruses"] >> weight_gain_viruses
+	S["weight_gain_nanites"] >> weight_gain_nanites
 	S["weight_gain_weapons"] >> weight_gain_weapons
 	S["weight_gain_extreme"] >> weight_gain_extreme
 	S["wg_rate"] >> wg_rate
@@ -293,6 +294,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["weight_gain_items"], weight_gain_items)
 	WRITE_FILE(S["weight_gain_magic"], weight_gain_magic)
 	WRITE_FILE(S["weight_gain_viruses"], weight_gain_viruses)
+	WRITE_FILE(S["weight_gain_nanites"], weight_gain_nanites)
 	WRITE_FILE(S["weight_gain_chems"], weight_gain_chems)
 	WRITE_FILE(S["weight_gain_weapons"], weight_gain_weapons)
 	WRITE_FILE(S["weight_gain_extreme"], weight_gain_extreme)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a preference that controls if nanites are able to fatten a player or not. Players can still lose weight through nanites.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Giving players more control is always good. This should also hopefully reduce the amount of OOC conversation needed when dealing with fattening nanites.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a preference for being fattened by nanites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
