### PR TITLE
Berry juice breast fluid fix, Mob resize size tweak

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -947,7 +947,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							if(/datum/reagent/consumable/nutriment)
 								dat += "<a style='display:block;width:50px' href='?_src_=prefs;preference=breasts_fluid;task=input'>Nutriment</a>"
 							if(/datum/reagent/blueberry_juice)
-								dat += "<a style='display:block;width:50px' href='?_src_=prefs;preference=balls_fluid;task=input'>Berry Juice</a>"
+								dat += "<a style='display:block;width:50px' href='?_src_=prefs;preference=breasts_fluid;task=input'>Berry Juice</a>"
 							else
 								dat += "<a style='display:block;width:50px' href='?_src_=prefs;preference=breasts_fluid;task=input'>Nothing?</a>"
 							//This else is a safeguard for errors, and if it happened, they wouldn't be able to change this pref,

--- a/hyperstation/code/modules/resize/resizing.dm
+++ b/hyperstation/code/modules/resize/resizing.dm
@@ -250,9 +250,9 @@ mob/living/get_effective_size()
 		mob_size = 0
 	if(size_multiplier < 1)
 		mob_size = 1
-	if(size_multiplier == 1)
+	if(size_multiplier <= 2)
 		mob_size = 2 //the default human size
-	if(size_multiplier > 1)
+	if(size_multiplier > 2)
 		mob_size = 3
 
 //Proc for instantly grabbing valid size difference. Code optimizations soon(TM)


### PR DESCRIPTION
Fixed being unbable to change one's breast fluid after selecting berry juice
Characters become unable to use things only over 200% size multiplier, not above 100%