### PR TITLE
Rebalances mining armors

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -25,7 +25,7 @@
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
-	armor = list("melee" = 30, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 35, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/suit/hooded/explorer/standard
@@ -138,7 +138,7 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	hoodtype = /obj/item/clothing/head/hooded/explorer/seva
 	armor = list("melee" = 15, "bullet" = 5, "laser" = 20, "energy" = 10, "bomb" = 25, "bio" = 100, "rad" = 25, "fire" = 100, "acid" = 25)
-	resistance_flags = FIRE_PROOF | GOLIATH_WEAKNESS
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/head/hooded/explorer/seva
 	name = "SEVA Hood"
@@ -147,7 +147,7 @@
 	item_state = "seva"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	armor = list("melee" = 10, "bullet" = 5, "laser" = 20, "energy" = 10, "bomb" = 25, "bio" = 100, "rad" = 25, "fire" = 100, "acid" = 25)
-	resistance_flags = FIRE_PROOF | GOLIATH_WEAKNESS
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/mask/gas/seva
 	name = "SEVA Mask"
@@ -167,7 +167,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	hoodtype = /obj/item/clothing/head/hooded/explorer/exo
-	armor = list("melee" = 60, "bullet" = 15, "laser" = 5, "energy" = 5, "bomb" = 60, "bio" = 25, "rad" = 10, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 50, "bullet" = 15, "laser" = 5, "energy" = 5, "bomb" = 60, "bio" = 25, "rad" = 10, "fire" = 0, "acid" = 0)
 	resistance_flags = FIRE_PROOF | GOLIATH_RESISTANCE
 
 /obj/item/clothing/head/hooded/explorer/exo
@@ -175,7 +175,7 @@
 	desc = "A recent model of a tactical helmet that lacks camouflage. It is not known how it made its way into GATO. The helmet is designed to provide a squad leader with strategic superiority over the enemy via its many scanners and satellite communications devices, which have not been installed in this particular helmet. Comes with multi-layered Kevlar protection and armored elements."
 	icon_state = "exo"
 	item_state = "exo"
-	armor = list("melee" = 60, "bullet" = 15, "laser" = 5, "energy" = 5, "bomb" = 60, "bio" = 25, "rad" = 10, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 50, "bullet" = 15, "laser" = 5, "energy" = 5, "bomb" = 60, "bio" = 25, "rad" = 10, "fire" = 0, "acid" = 0)
 	resistance_flags = FIRE_PROOF | GOLIATH_RESISTANCE
 
 /obj/item/clothing/mask/gas/exo


### PR DESCRIPTION
Rebalances Mining Armors. 

Increases Explorer Suits melee defense by 5, giving it a total of 65% when fully upgraded, still lower than heavier options E.G. Mining hardsuit/Unique lavaland hardsuits.

Decreases Exo Suits melee defense to 50. Starts strong but gets outpaced by the Explorer Suit. Maintains Goliath stun resistance.

Remove SEVA Suits Goliath vulnerability trait. The suit already has low armor values, these are punishing enough for immediate storm-resistance. 