### PR TITLE
Upgrading Hermit Lathes.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_duohermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_duohermit.dmm
@@ -40,12 +40,13 @@
 "O" = (/obj/machinery/door/airlock/titanium{name = "Escape Pod Airlock"},/turf/open/floor/mineral/titanium/blue,/area/ruin/powered)
 "Q" = (/obj/item/weldingtool,/turf/open/floor/mineral/titanium/blue,/area/ruin/powered)
 "R" = (/obj/item/stack/cable_coil/red,/turf/open/floor/plating/asteroid/basalt,/area/ruin/powered)
+"S" = (/obj/item/card/id/away{access = list(); name = "Weathered Mining ID"; desc = "Some ancient, worn down mining ID card, the magnetic strips for the access have long since worn away. It might still have a use though"; mining_points = 16},/turf/open/floor/plating,/area/ruin/powered)
 "T" = (/obj/item/stock_parts/matter_bin,/turf/open/floor/plating/asteroid/basalt,/area/ruin/powered)
 "U" = (/obj/item/stock_parts/matter_bin,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "V" = (/turf/closed/wall/mineral/titanium/interior,/area/ruin/powered)
 "W" = (/obj/structure/shuttle/engine/propulsion/burst{dir = 8},/turf/closed/wall/mineral/titanium/interior,/area/ruin/powered)
 "Y" = (/obj/item/mining_scanner,/turf/open/floor/plating/asteroid/basalt,/area/ruin/powered)
-"Z" = (/obj/item/circuitboard/machine/protolathe/department/science,/obj/item/circuitboard/computer/rdconsole,/turf/open/floor/plating/asteroid/basalt,/area/ruin/powered)
+"Z" = (/obj/item/circuitboard/computer/rdconsole,/obj/item/circuitboard/machine/protolathe,/turf/open/floor/plating/asteroid/basalt,/area/ruin/powered)
 
 (1,1,1) = {"
 aaaaaaaccccaaaaa
@@ -56,7 +57,7 @@ aacJfYffLilkcaaa
 aaccfffffgncaaaa
 aaacffZfRfpcaaaa
 aaacTfoqofrcaaaa
-saactttooucaaaaa
+saactttoSucaaaaa
 saaatvwooKcaaaaa
 sssatxyztAcaaaaa
 sssstxyCtcWVVaaa

--- a/_maps/RandomRuins/SpaceRuins/spacehermit.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehermit.dmm
@@ -137,7 +137,7 @@
 /area/ruin/unpowered)
 "aD" = (
 /obj/item/circuitboard/computer/rdconsole,
-/obj/item/circuitboard/machine/protolathe/department/science,
+/obj/item/circuitboard/machine/protolathe,
 /turf/open/floor/plating/asteroid,
 /area/ruin/unpowered)
 "aE" = (
@@ -223,13 +223,6 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"aW" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/item/clothing/suit/space/orange,
-/turf/open/floor/mineral/titanium,
-/area/ruin/powered)
 "aX" = (
 /mob/living/simple_animal/hostile/carp/megacarp,
 /turf/template_noop,
@@ -354,18 +347,10 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/ruin/powered)
-"eX" = (
-/obj/item/clothing/head/helmet/space/orange,
-/turf/open/floor/mineral/titanium,
-/area/ruin/powered)
 "kU" = (
 /mob/living/simple_animal/hostile/carp,
 /turf/closed/mineral/random/low_chance,
 /area/ruin/unpowered)
-"Qy" = (
-/obj/item/tank/internals/emergency_oxygen/empty,
-/turf/open/floor/mineral/titanium,
-/area/ruin/powered)
 
 (1,1,1) = {"
 aa
@@ -1027,7 +1012,7 @@ ab
 ab
 af
 aY
-aW
+ao
 ao
 ao
 ak
@@ -1183,8 +1168,8 @@ ab
 aR
 ae
 ae
-Qy
-eX
+an
+an
 an
 ae
 aZ


### PR DESCRIPTION
Woe. 
Omnilathes Upon Ye!

Gives Duo Lavaland and Space Hermits Omnilathes instead of Science Protolathes. 
Removes the random space suit added to the Space Hermits role, it's back to the original where the only suit is outside the asteroid.